### PR TITLE
Adds numerous health checks to the Orleans silo host project

### DIFF
--- a/src/Kritner.Orleans.GettingStarted.GrainInterfaces/HealthChecks/IBasicHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.GrainInterfaces/HealthChecks/IBasicHealthCheckGrain.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+
+namespace Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks
+{
+	public interface IBasicHealthCheckGrain : IHealthCheck, IGrainWithGuidKey
+	{
+		
+	}
+}

--- a/src/Kritner.Orleans.GettingStarted.GrainInterfaces/HealthChecks/ICpuHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.GrainInterfaces/HealthChecks/ICpuHealthCheckGrain.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+
+namespace Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks
+{
+	public interface ICpuHealthCheckGrain : IHealthCheck, IGrainWithGuidKey
+	{
+		
+	}
+}

--- a/src/Kritner.Orleans.GettingStarted.GrainInterfaces/HealthChecks/IMemoryHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.GrainInterfaces/HealthChecks/IMemoryHealthCheckGrain.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+
+namespace Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks
+{
+	public interface IMemoryHealthCheckGrain : IHealthCheck, IGrainWithGuidKey
+	{
+		
+	}
+}

--- a/src/Kritner.Orleans.GettingStarted.GrainInterfaces/Kritner.Orleans.GettingStarted.GrainInterfaces.csproj
+++ b/src/Kritner.Orleans.GettingStarted.GrainInterfaces/Kritner.Orleans.GettingStarted.GrainInterfaces.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.3.0" />
     <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.8" />
   </ItemGroup>
 
 </Project>

--- a/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/BasicHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/BasicHealthCheckGrain.cs
@@ -1,0 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+using Orleans.Concurrency;
+
+namespace Kritner.Orleans.GettingStarted.Grains.HealthChecks
+{
+	[StatelessWorker(1)]
+	public class BasicHealthCheckGrain : Grain, IBasicHealthCheckGrain
+	{
+		public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+		{
+			return Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));
+		}
+	}
+}

--- a/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/CpuHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/CpuHealthCheckGrain.cs
@@ -3,10 +3,12 @@ using System.Threading.Tasks;
 using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Orleans;
+using Orleans.Concurrency;
 using Orleans.Statistics;
 
 namespace Kritner.Orleans.GettingStarted.Grains.HealthChecks
 {
+	[StatelessWorker(1)]
 	public class CpuHealthCheckGrain : Grain, ICpuHealthCheckGrain
 	{
 		private const float UnhealthyThreshold = 90;

--- a/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/CpuHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/CpuHealthCheckGrain.cs
@@ -33,11 +33,11 @@ namespace Kritner.Orleans.GettingStarted.Grains.HealthChecks
 			if (_hostEnvironmentStatistics.CpuUsage > DegradedThreshold)
 			{
 				return Task.FromResult(HealthCheckResult.Degraded(
-					$"CPU utilization is unhealthy at {_hostEnvironmentStatistics.CpuUsage * 100}%."));
+					$"CPU utilization is degraded at {_hostEnvironmentStatistics.CpuUsage * 100}%."));
 			}
 			
 			return Task.FromResult(HealthCheckResult.Healthy(
-				$"CPU utilization is unhealthy at {_hostEnvironmentStatistics.CpuUsage * 100}%."));
+				$"CPU utilization is healthy at {_hostEnvironmentStatistics.CpuUsage * 100}%."));
 		}
 	}
 }

--- a/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/CpuHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/CpuHealthCheckGrain.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+using Orleans.Statistics;
+
+namespace Kritner.Orleans.GettingStarted.Grains.HealthChecks
+{
+	public class CpuHealthCheckGrain : Grain, ICpuHealthCheckGrain
+	{
+		private const float UnhealthyThreshold = 90;
+		private const float DegradedThreshold = 70;
+		
+		private readonly IHostEnvironmentStatistics _hostEnvironmentStatistics;
+
+		public CpuHealthCheckGrain(IHostEnvironmentStatistics hostEnvironmentStatistics)
+		{
+			_hostEnvironmentStatistics = hostEnvironmentStatistics;
+		}
+		
+		public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+		{
+			if (_hostEnvironmentStatistics.CpuUsage > UnhealthyThreshold)
+			{
+				return Task.FromResult(HealthCheckResult.Unhealthy(
+					$"CPU utilization is unhealthy at {_hostEnvironmentStatistics.CpuUsage * 100}%."));
+				
+			}
+			
+			if (_hostEnvironmentStatistics.CpuUsage > DegradedThreshold)
+			{
+				return Task.FromResult(HealthCheckResult.Degraded(
+					$"CPU utilization is unhealthy at {_hostEnvironmentStatistics.CpuUsage * 100}%."));
+			}
+			
+			return Task.FromResult(HealthCheckResult.Healthy(
+				$"CPU utilization is unhealthy at {_hostEnvironmentStatistics.CpuUsage * 100}%."));
+		}
+	}
+}

--- a/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/MemoryHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/MemoryHealthCheckGrain.cs
@@ -45,11 +45,11 @@ namespace Kritner.Orleans.GettingStarted.Grains.HealthChecks
 			if (memoryUsed > DegradedThreshold)
 			{
 				return Task.FromResult(HealthCheckResult.Degraded(
-					$"Memory utilization is unhealthy at {memoryUsed:0.00}%."));
+					$"Memory utilization is degraded at {memoryUsed:0.00}%."));
 			}
 			
 			return Task.FromResult(HealthCheckResult.Healthy(
-				$"Memory utilization is unhealthy at {memoryUsed:0.00}%."));
+				$"Memory utilization is healthy at {memoryUsed:0.00}%."));
 		}
 	}
 }

--- a/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/MemoryHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/MemoryHealthCheckGrain.cs
@@ -1,0 +1,53 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+using Orleans.Statistics;
+
+namespace Kritner.Orleans.GettingStarted.Grains.HealthChecks
+{
+	public class MemoryHealthCheckGrain : Grain, IMemoryHealthCheckGrain
+	{
+		private const float UnhealthyThreshold = 95;
+		private const float DegradedThreshold = 90;
+		
+		private readonly IHostEnvironmentStatistics _hostEnvironmentStatistics;
+
+		public MemoryHealthCheckGrain(IHostEnvironmentStatistics hostEnvironmentStatistics)
+		{
+			_hostEnvironmentStatistics = hostEnvironmentStatistics;
+		}
+		
+		public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+		{
+			if (_hostEnvironmentStatistics?.AvailableMemory == null || _hostEnvironmentStatistics?.TotalPhysicalMemory == null)
+			{
+				return Task.FromResult(HealthCheckResult.Unhealthy("Could not determine memory calculation."));
+			}
+			
+			if (_hostEnvironmentStatistics?.AvailableMemory == 0 && _hostEnvironmentStatistics?.AvailableMemory == 0)
+			{
+				return Task.FromResult(HealthCheckResult.Unhealthy("Could not determine memory calculation."));
+			}
+			
+			var memoryUsed = 100 - ((float)_hostEnvironmentStatistics.AvailableMemory / (float)_hostEnvironmentStatistics.TotalPhysicalMemory * 100);
+			
+			if (memoryUsed > UnhealthyThreshold)
+			{
+				return Task.FromResult(HealthCheckResult.Unhealthy(
+					$"Memory utilization is unhealthy at {memoryUsed:0.00}%."));
+				
+			}
+			
+			if (memoryUsed > DegradedThreshold)
+			{
+				return Task.FromResult(HealthCheckResult.Degraded(
+					$"Memory utilization is unhealthy at {memoryUsed:0.00}%."));
+			}
+			
+			return Task.FromResult(HealthCheckResult.Healthy(
+				$"Memory utilization is unhealthy at {memoryUsed:0.00}%."));
+		}
+	}
+}

--- a/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/MemoryHealthCheckGrain.cs
+++ b/src/Kritner.Orleans.GettingStarted.Grains/HealthChecks/MemoryHealthCheckGrain.cs
@@ -3,10 +3,12 @@ using System.Threading.Tasks;
 using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Orleans;
+using Orleans.Concurrency;
 using Orleans.Statistics;
 
 namespace Kritner.Orleans.GettingStarted.Grains.HealthChecks
 {
+	[StatelessWorker(1)]
 	public class MemoryHealthCheckGrain : Grain, IMemoryHealthCheckGrain
 	{
 		private const float UnhealthyThreshold = 95;

--- a/src/Kritner.Orleans.GettingStarted.Grains/Kritner.Orleans.GettingStarted.Grains.csproj
+++ b/src/Kritner.Orleans.GettingStarted.Grains/Kritner.Orleans.GettingStarted.Grains.csproj
@@ -5,9 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="3.3.0" />
     <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kritner.OrleansGettingStarted.SiloHost/HealthChecks/BasicOrleansHealthCheck.cs
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/HealthChecks/BasicOrleansHealthCheck.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+
+namespace Kritner.OrleansGettingStarted.SiloHost.HealthChecks
+{
+	public class BasicOrleansHealthCheck :  OrleansHealthCheckBase
+	{
+		public BasicOrleansHealthCheck(IClusterClient client) : base(client)
+		{
+			
+		}
+		
+		protected override async Task<HealthCheckResult> CheckHealthGrainAsync(HealthCheckContext context, CancellationToken cancellationToken)
+		{
+			try
+			{
+				return await _client.GetGrain<IBasicHealthCheckGrain>(Guid.Empty)
+					.CheckHealthAsync(context, cancellationToken);
+			}
+			catch (Exception e)
+			{
+				return HealthCheckResult.Unhealthy($"Health check failed.", e);
+			}
+		}
+	}
+}

--- a/src/Kritner.OrleansGettingStarted.SiloHost/HealthChecks/CpuOrleansHealthCheck.cs
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/HealthChecks/CpuOrleansHealthCheck.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+
+namespace Kritner.OrleansGettingStarted.SiloHost.HealthChecks
+{
+	public class CpuOrleansHealthCheck : OrleansHealthCheckBase
+	{
+		public CpuOrleansHealthCheck(IClusterClient client) : base(client)
+		{
+		}
+		
+		protected override async Task<HealthCheckResult> CheckHealthGrainAsync(HealthCheckContext context, CancellationToken cancellationToken)
+		{
+			try
+			{
+				return await _client.GetGrain<ICpuHealthCheckGrain>(Guid.Empty)
+					.CheckHealthAsync(context, cancellationToken);
+			}
+			catch (Exception e)
+			{
+				return HealthCheckResult.Unhealthy($"Health check failed.", e);
+			}
+		}
+	}
+}

--- a/src/Kritner.OrleansGettingStarted.SiloHost/HealthChecks/MemoryOrleansHealthCheck.cs
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/HealthChecks/MemoryOrleansHealthCheck.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+
+namespace Kritner.OrleansGettingStarted.SiloHost.HealthChecks
+{
+	public class MemoryOrleansHealthCheck : OrleansHealthCheckBase
+	{
+		public MemoryOrleansHealthCheck(IClusterClient client) : base(client)
+		{
+		}
+		
+		protected override async Task<HealthCheckResult> CheckHealthGrainAsync(HealthCheckContext context, CancellationToken cancellationToken)
+		{
+			try
+			{
+				return await _client.GetGrain<IMemoryHealthCheckGrain>(Guid.Empty)
+					.CheckHealthAsync(context, cancellationToken);
+			}
+			catch (Exception e)
+			{
+				return HealthCheckResult.Unhealthy($"Health check failed.", e);
+			}
+		}
+	}
+}

--- a/src/Kritner.OrleansGettingStarted.SiloHost/HealthChecks/OrleansHealthCheckBase.cs
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/HealthChecks/OrleansHealthCheckBase.cs
@@ -1,0 +1,41 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Orleans;
+
+namespace Kritner.OrleansGettingStarted.SiloHost.HealthChecks
+{
+	public abstract class OrleansHealthCheckBase : IHealthCheck
+	{
+		protected readonly IClusterClient _client;
+
+		protected OrleansHealthCheckBase(IClusterClient client)
+		{
+			_client = client;
+		}
+		
+		/// <summary>
+		/// Entry into health check, ensures the client is initialized, if it is not returns a healthy status.
+		/// </summary>
+		/// <param name="context">The health check context.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns><see cref="Task"/> of <see cref="HealthCheckResult"/></returns>
+		public virtual async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = new CancellationToken())
+		{
+			if (!_client.IsInitialized)
+			{
+				return HealthCheckResult.Healthy($"{nameof(_client)} not yet initialized.");
+			}
+
+			return await CheckHealthGrainAsync(context, cancellationToken);
+		}
+
+		/// <summary>
+		/// Perform the actual health check work within this implemented method.
+		/// </summary>
+		/// <param name="context">The health check context.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns><see cref="Task"/> of <see cref="HealthCheckResult"/></returns>
+		protected abstract Task<HealthCheckResult> CheckHealthGrainAsync(HealthCheckContext context, CancellationToken cancellationToken);
+	}
+}

--- a/src/Kritner.OrleansGettingStarted.SiloHost/Helpers/DependencyInjectionHelper.cs
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/Helpers/DependencyInjectionHelper.cs
@@ -1,5 +1,7 @@
 ﻿using Kritner.Orleans.GettingStarted.GrainInterfaces;
+using Kritner.Orleans.GettingStarted.GrainInterfaces.HealthChecks;
 using Kritner.Orleans.GettingStarted.Grains;
+using Kritner.Orleans.GettingStarted.Grains.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Kritner.OrleansGettingStarted.SiloHost.Helpers

--- a/src/Kritner.OrleansGettingStarted.SiloHost/Kritner.OrleansGettingStarted.SiloHost.csproj
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/Kritner.OrleansGettingStarted.SiloHost.csproj
@@ -24,4 +24,8 @@
     <Content Include="..\_appsettings\appsettings.dev.json" Link="appsettings.dev.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="OrleansGrainHealthChecks" />
+  </ItemGroup>
+
 </Project>

--- a/src/Kritner.OrleansGettingStarted.SiloHost/Kritner.OrleansGettingStarted.SiloHost.csproj
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/Kritner.OrleansGettingStarted.SiloHost.csproj
@@ -24,8 +24,4 @@
     <Content Include="..\_appsettings\appsettings.dev.json" Link="appsettings.dev.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="OrleansGrainHealthChecks" />
-  </ItemGroup>
-
 </Project>

--- a/src/Kritner.OrleansGettingStarted.SiloHost/Program.cs
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/Program.cs
@@ -2,16 +2,14 @@
 using Kritner.Orleans.GettingStarted.Grains;
 using Kritner.OrleansGettingStarted.SiloHost.ExtensionMethods;
 using Kritner.OrleansGettingStarted.SiloHost.Helpers;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Orleans;
 using Orleans.Configuration;
 using Orleans.Hosting;
 using Orleans.Statistics;
-using System;
 using System.Threading.Tasks;
 using Kritner.OrleansGettingStarted.Common.Helpers;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -35,6 +33,8 @@ namespace Kritner.OrleansGettingStarted.SiloHost
                     context.HostingEnvironment.EnvironmentName = env;
                     builder.AddConfiguration(configurationRoot);
                 })
+                .ConfigureServices(DependencyInjectionHelper.IocContainerRegistration)
+                .ConfigureWebHostDefaults(builder => { builder.UseStartup<Startup>(); })
                 .UseOrleans(siloBuilder =>
                 {
                     siloBuilder
@@ -47,16 +47,19 @@ namespace Kritner.OrleansGettingStarted.SiloHost
                             options.ClusterId = "dev";
                             options.ServiceId = "HelloWorldApp";
                         })
-                            .AddMemoryGrainStorage(Constants.OrleansMemoryProvider)
-                            .ConfigureApplicationParts(parts =>
-                            {
-                                parts.AddApplicationPart(typeof(IGrainMarker).Assembly).WithReferences();
-                            })
-                            .ConfigureServices(DependencyInjectionHelper.IocContainerRegistration)
-                            .UsePerfCounterEnvironmentStatistics()
-                            .UseDashboard(options => { })
-                            .UseInMemoryReminderService()
-                            .ConfigureLogging(logging => logging.AddConsole());
+                        .AddMemoryGrainStorage(Constants.OrleansMemoryProvider)
+                        .ConfigureApplicationParts(parts =>
+                        {
+                            parts.AddApplicationPart(typeof(IGrainMarker).Assembly).WithReferences();
+                        })
+                        .UsePerfCounterEnvironmentStatistics()
+                        .UseDashboard(options => { })
+                        .UseInMemoryReminderService()
+                        .ConfigureLogging(logging =>
+                        {
+                            logging.SetMinimumLevel(LogLevel.Warning);
+                            logging.AddConsole();
+                        });
                 });
         }
     }

--- a/src/Kritner.OrleansGettingStarted.SiloHost/Startup.cs
+++ b/src/Kritner.OrleansGettingStarted.SiloHost/Startup.cs
@@ -1,0 +1,51 @@
+using Kritner.OrleansGettingStarted.SiloHost.HealthChecks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Kritner.OrleansGettingStarted.SiloHost
+{
+	public class Startup
+	{
+		public Startup(IConfiguration configuration)
+		{
+			Configuration = configuration;
+		}
+
+		public IConfiguration Configuration { get; }
+
+		// This method gets called by the runtime. Use this method to add services to the container.
+		public void ConfigureServices(IServiceCollection services)
+		{
+			services.AddControllers();
+			services.AddHealthChecks()
+				.AddCheck<BasicOrleansHealthCheck>("basicOrleans")
+				.AddCheck<CpuOrleansHealthCheck>("cpuOrleans")
+				.AddCheck<MemoryOrleansHealthCheck>("memoryOrleans");
+		}
+
+		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+		{
+			if (env.IsDevelopment())
+			{
+				app.UseDeveloperExceptionPage();
+			}
+
+			app.UseHttpsRedirection();
+
+			app.UseRouting();
+
+			app.UseAuthorization();
+
+			app.UseEndpoints(endpoints =>
+			{
+				endpoints.MapHealthChecks("/health").WithMetadata(new AllowAnonymousAttribute());
+				endpoints.MapControllers();
+			});
+		}
+	}
+}


### PR DESCRIPTION
* Basic - ensures the cluster can create a grain and return the status without exception
* CPU - returns "Degraded" when the CPU is above 70%, "Unhealthy" if above 90%
* Memory - returns "Degraded" when the memory usage is above 90%, Unhealthy when above 95%
* Adds web host as separate hosted project within the silo host, run along with the orleans silo host